### PR TITLE
pkgman: optional manifest rows (--install-optionals)

### DIFF
--- a/pkgman/pkgman
+++ b/pkgman/pkgman
@@ -112,6 +112,10 @@ _NO_TRACK=false
 _HOST=""
 _PRUNE=false
 _FORCE=false
+# Manifest optionals: "" = install no optional-tagged rows (default); "all" =
+# install every optional row in scope; a comma-list of names = install only
+# those. Optional rows are ALWAYS declared (never pruned) regardless of this.
+_INSTALL_OPTIONALS=""
 
 # Status constants
 readonly _PKGMAN_STATUS_INSTALLED="installed"
@@ -167,6 +171,14 @@ _main() {
         ;;
       --prune)
         _PRUNE=true
+        shift
+        ;;
+      --install-optionals)
+        _INSTALL_OPTIONALS="all"
+        shift
+        ;;
+      --install-optionals=*)
+        _INSTALL_OPTIONALS="${1#*=}"
         shift
         ;;
       --force)
@@ -250,6 +262,11 @@ _main() {
     version) _version; exit 0 ;;
     # Hidden test-only command: exposes _tags_match without needing to source pkgman
     __tags-match) _tags_match "$@"; exit $? ;;
+    # Hidden: list applicable optional rows (name|desc) for an interactive caller
+    __manifest-optionals)
+      [[ -f "${1:-}" ]] || { u.error "__manifest-optionals: manifest file required"; exit $_E_USG; }
+      [[ -n "$_HOST" ]] || { u.error "__manifest-optionals: --host required"; exit $_E_USG; }
+      _manifest_optional_names "$1" "$(loam.os)" "$_HOST"; exit $? ;;
     *) u.error "unknown command: $_command"; _help; exit $_E_USG ;;
   esac
 }
@@ -453,6 +470,24 @@ _tags_match() {  # $1=tags $2=os $3=host ; return 0 if row applies
   return 0
 }
 
+##@ True if a row's tags mark it optional. 'optional' is an ordinary token in
+##@ the tags column (e.g. 'mac,optional'); _tags_match ignores it (it is neither
+##@ an OS nor a host), so an optional row still filters correctly by os/host.
+##@ Usage: _row_is_optional "$_tags" && ...
+_row_is_optional() {  # $1=tags ; return 0 if optional
+  case ",${1// /}," in *,optional,*) return 0 ;; *) return 1 ;; esac
+}
+
+##@ True if an optional row named $1 should be installed given _INSTALL_OPTIONALS.
+##@ "" -> never; "all" -> always; else membership in the comma-list.
+_optional_approved() {  # $1=name ; return 0 if approved for install
+  case "$_INSTALL_OPTIONALS" in
+    "") return 1 ;;
+    all) return 0 ;;
+    *) case ",${_INSTALL_OPTIONALS// /}," in *,"$1",*) return 0 ;; *) return 1 ;; esac ;;
+  esac
+}
+
 ##@ Strip leading/trailing whitespace from a string, preserving internal whitespace
 ##@ Usage: _trimmed="$(_manifest_trim "$_raw")"
 _manifest_trim() {
@@ -475,7 +510,7 @@ _manifest_apply() {
   [[ "$_mode" == "install" ]] || { u.error "manifest: unsupported mode '$_mode'"; return $_E_USG; }
 
   local _name _handler _desc _params _tags
-  local _applied=0 _skipped_tags=0 _skipped_handler=0
+  local _applied=0 _skipped_tags=0 _skipped_handler=0 _skipped_optional=0
   while IFS='|' read -r _name _handler _desc _params _tags || [[ -n "$_name" ]]; do
     _name="$(_manifest_trim "${_name:-}")"
     [[ -z "$_name" ]] && continue
@@ -488,6 +523,13 @@ _manifest_apply() {
 
     if ! _tags_match "$_tags" "$_os" "$_host" </dev/null; then
       _skipped_tags=$((_skipped_tags + 1))
+      continue
+    fi
+
+    # Optional rows are installed only when approved (--install-optionals);
+    # otherwise skipped for install BUT still declared (prune-safe) elsewhere.
+    if _row_is_optional "$_tags" && ! _optional_approved "$_name"; then
+      _skipped_optional=$((_skipped_optional + 1))
       continue
     fi
 
@@ -533,7 +575,7 @@ _manifest_apply() {
     _applied=$((_applied + 1))
   done < "$_file"
 
-  u.info "✓ manifest applied: $_applied row(s) processed, $_skipped_tags filtered by tags, $_skipped_handler skipped (unknown handler)"
+  u.info "✓ manifest applied: $_applied row(s) processed, $_skipped_tags filtered by tags, $_skipped_handler skipped (unknown handler), $_skipped_optional optional (not selected)"
   return 0
 }
 
@@ -559,6 +601,26 @@ _manifest_declared_names() {  # $1=file $2=os $3=host -> applicable names, one p
     _tags_match "$_tags" "$_os" "$_host" </dev/null || continue
 
     echo "$_name"
+  done < "$_file"
+  return 0
+}
+
+##@ List applicable OPTIONAL rows as 'name|desc', one per line (os/host filtered).
+##@ For an interactive caller (e.g. kickstart) to enumerate + prompt, then pass
+##@ the accepted names back via --install-optionals=<csv>. Read-only.
+##@ Usage: _manifest_optional_names <file> <os> <host>
+_manifest_optional_names() {  # $1=file $2=os $3=host -> "name|desc" per optional row
+  local _file="$1" _os="$2" _host="$3"
+  local _name _handler _desc _params _tags
+  while IFS='|' read -r _name _handler _desc _params _tags || [[ -n "$_name" ]]; do
+    _name="$(_manifest_trim "${_name:-}")"
+    [[ -z "$_name" ]] && continue
+    case "$_name" in \#*) continue ;; esac
+    _desc="$(_manifest_trim "${_desc:-}")"
+    _tags="$(_manifest_trim "${_tags:-}")"
+    _tags_match "$_tags" "$_os" "$_host" </dev/null || continue
+    _row_is_optional "$_tags" || continue
+    printf '%s|%s\n' "$_name" "$_desc"
   done < "$_file"
   return 0
 }
@@ -2078,6 +2140,11 @@ GLOBAL OPTIONS:
     --host <h>          Target host tag for manifest mode (REQUIRED with install/sync <manifest>)
     --prune             With sync <manifest>: remove undeclared pkgman-managed core packages
                           (report-only without this flag)
+    --install-optionals[=all|<name,...>]
+                          With install/sync <manifest>: install rows tagged 'optional'.
+                          Bare or '=all' installs every optional in scope; '=name1,name2'
+                          installs only those. Default (omitted): optionals are skipped for
+                          install but still DECLARED, so an installed optional is never pruned.
     -h, --help          Show this help
     -v, --version       Show version
 

--- a/pkgman/tests.sh
+++ b/pkgman/tests.sh
@@ -305,4 +305,50 @@ zzz9   | script | mock Z9 | source=./mocks/mock-pkg!name=zzz9   |" > "$_man"
   rm -f "$_man"
 }
 
+test_manifest_optionals() {
+  _section_header "P1: optional rows — skipped by default, selectable, always declared (prune-safe)"
+  setup_cfg
+  export MOCK_STATE; MOCK_STATE=$(mktemp -d "${TMPDIR:-/tmp}/mock-XXXXXX")
+
+  # one required row + two optional rows, tagged for THIS platform so the suite
+  # is platform-agnostic (see the fixture note at the top of this file).
+  local _m; _m=$(mktemp "${TMPDIR:-/tmp}/opt-manifest-XXXXXX")
+  {
+    printf 'req  | script | required     | source=./mocks/mock-pkg!name=req  | %s\n' "$THIS_OS"
+    printf 'opt1 | script | optional one | source=./mocks/mock-pkg!name=opt1 | %s,optional\n' "$THIS_OS"
+    printf 'opt2 | script | optional two | source=./mocks/mock-pkg!name=opt2 | %s,optional\n' "$THIS_OS"
+  } > "$_m"
+
+  # 1) default: optionals skipped for install; required row installed
+  assert_ok $TOOL install "$_m" --host macmini "install without --install-optionals runs"
+  assert_file_exists "$MOCK_STATE/req"    "required row installed"
+  assert_ok test ! -f "$MOCK_STATE/opt1"  "optional opt1 skipped by default"
+  assert_ok test ! -f "$MOCK_STATE/opt2"  "optional opt2 skipped by default"
+
+  # 2) enumerator lists applicable optional rows with descriptions, excludes non-optional
+  local _lf; _lf=$(mktemp "${TMPDIR:-/tmp}/opt-list-XXXXXX")
+  $TOOL __manifest-optionals "$_m" --host macmini > "$_lf" 2>/dev/null
+  assert_ok   grep -q '^opt1|optional one' "$_lf" "enumerator lists opt1 with desc"
+  assert_ok   grep -q '^opt2|optional two' "$_lf" "enumerator lists opt2 with desc"
+  assert_fail grep -q '^req|' "$_lf" "enumerator excludes the non-optional row"
+
+  # 3) --install-optionals=opt1 installs only that one (csv subset)
+  assert_ok $TOOL install "$_m" --host macmini --install-optionals=opt1 "install with --install-optionals=opt1"
+  assert_file_exists "$MOCK_STATE/opt1"   "opt1 installed by name"
+  assert_ok test ! -f "$MOCK_STATE/opt2"  "opt2 still skipped (not in the csv)"
+
+  # 4) --install-optionals=all installs the remainder
+  assert_ok $TOOL install "$_m" --host macmini --install-optionals=all "install with --install-optionals=all"
+  assert_file_exists "$MOCK_STATE/opt2"   "opt2 installed under =all"
+
+  # 5) prune protection: an installed optional is STILL declared, so a plain
+  #    sync --prune (optionals not selected this run) must not remove it.
+  assert_ok $TOOL sync "$_m" --host macmini --prune --force "sync --prune with optionals unselected"
+  assert_file_exists "$MOCK_STATE/opt1"   "installed optional opt1 not pruned (still declared)"
+  assert_file_exists "$MOCK_STATE/opt2"   "installed optional opt2 not pruned (still declared)"
+  assert_ok grep -q '^opt2.manager=' "$PKGMAN_CONFIG_DIR/index/package.core.cfg" "opt2 still tracked after prune"
+
+  rm -f "$_m" "$_lf"
+}
+
 _test_runner


### PR DESCRIPTION
## What

Adds a first-class **optional** concept to pkgman's manifest ingestion, requested for radix's fleet manifest (packages you want on *some* machines / on demand, not auto-installed everywhere).

A row is optional when its **tags** column contains `optional` (e.g. `pixelmator-pro | mas | image editor | source=1289583905 | mac,optional`). `_tags_match` already ignores non-OS/non-host tokens, so os/host filtering is unaffected.

## Behavior

- **`install`/`sync <manifest>`**: optional rows are **skipped for install** unless selected via `--install-optionals`:
  - bare `--install-optionals` or `--install-optionals=all` → install every optional in scope
  - `--install-optionals=name1,name2` → install only those
  - omitted (default) → optionals skipped
- **Prune protection**: optional rows are **always** included in `_manifest_declared_names`, so an installed optional is never treated as undeclared by `sync --prune`. (Skipped-for-install ≠ undeclared.)
- **`__manifest-optionals <file> --host H`** (hidden): lists applicable optional rows as `name|desc` for an interactive caller to enumerate + prompt, then pass the accepted names back via `--install-optionals=<csv>`.

## Design note

The interactive confirmation lives in the **caller** (kickstart), not pkgman — pkgman is invoked `</dev/null` (LEARNINGS #13), so a stdin prompt here would EOF to "no", exactly the dead-confirm trap the `sync --prune` path already solved. So the split is identical: caller owns the tty prompt, pkgman takes the resolved selection as a flag.

## Tests

16 new assertions (`test_manifest_optionals`): default-skip, csv subset, `=all`, enumerator contents, and prune-protection of an installed optional. Full suite **187 green** on bash 3.2; `make lint` + `make test` (6 tools) clean.

## Follow-up (not in this PR)

`_tags_match` hardcodes `laptop|macmini|server` as its host vocabulary — stale now that radix uses `bytepod`, and awkward for a generic tool. No current manifest row uses an unrecognized host tag, so it's latent; worth a separate issue to make the host vocabulary configurable.