### PR TITLE
pkgman follow-ups: #7 #8 #9 #11 #12a (host vocab, row-failure, cask source, script search, tags leak)

### DIFF
--- a/pkgman/pkglib
+++ b/pkgman/pkglib
@@ -312,9 +312,12 @@ _pkglib.resolve_source_path() {
   
   # Search priority order for relative paths:
   local _search_paths=(
+    # 0. pkgman's own dir (dogfooding: a self-hosted provision runs script rows like `pkgboot`
+    #    that live beside pkgman itself — e.g. radix seeds shed then provisions from it)
+    "$(dirname "${BASH_SOURCE[0]}")/$_source"
     # 1. Relative to current script's bin directory (for pkglib in lib/, check ../bin/)
     "$(dirname "${BASH_SOURCE[0]}")/../bin/$_source"
-    # 2. Relative to current script's ins directory (for pkglib in lib/, check ../ins/)  
+    # 2. Relative to current script's ins directory (for pkglib in lib/, check ../ins/)
     "$(dirname "${BASH_SOURCE[0]}")/../ins/$_source"
     # 3. Standard locations
     "$HOME/.local/bin/$_source"

--- a/pkgman/pkgman
+++ b/pkgman/pkgman
@@ -457,16 +457,30 @@ _validate_os_compatibility() {
 
 ##@ Check whether a package's tags allow it to apply on the given os/host
 ##@ Empty tags always match. Tags containing mac|linux require that os to match;
-##@ tags containing laptop|macmini|server require that host to match. Host is
-##@ ALWAYS passed in by the caller (--host) - never derived from the local machine.
+##@ OS tokens (mac|linux) filter by OS; RESERVED keywords (optional) are ignored here;
+##@ ANY OTHER token is treated as a HOST tag — so any host value works with no hardcoded
+##@ fleet list. If a row names any host token, --host must be among them. Host is ALWAYS
+##@ passed in by the caller (--host), never derived from the local machine.
 ##@ Usage: _tags_match "$_tags" "$_os" "$_host" || continue
 _tags_match() {  # $1=tags $2=os $3=host ; return 0 if row applies
   local _t=",${1// /}," _os="$2" _host="$3"
   [[ "$_t" == ",," ]] && return 0
+  # OS filter: if the row names any known OS, ours must be among them.
   case "$_t" in *,mac,*|*,linux,*)
     case "$_t" in *,"$_os",*) ;; *) return 1;; esac ;; esac
-  case "$_t" in *,laptop,*|*,macmini,*|*,server,*)
-    case "$_t" in *,"$_host",*) ;; *) return 1;; esac ;; esac
+  # Host filter: any non-OS, non-reserved token is a host tag. Collect them; if any
+  # exist, --host must match one. (No hardcoded host vocabulary — laptop/bytepod/server
+  # or any future host value all work; `optional` and OS tokens are never hosts.)
+  local _tok _has_host=0 _host_ok=0 _oldifs="$IFS"
+  IFS=','
+  for _tok in $_t; do
+    [[ -z "$_tok" ]] && continue
+    case "$_tok" in mac|linux|optional) continue ;; esac
+    _has_host=1
+    [[ "$_tok" == "$_host" ]] && _host_ok=1
+  done
+  IFS="$_oldifs"
+  [[ $_has_host -eq 1 && $_host_ok -eq 0 ]] && return 1
   return 0
 }
 
@@ -510,7 +524,7 @@ _manifest_apply() {
   [[ "$_mode" == "install" ]] || { u.error "manifest: unsupported mode '$_mode'"; return $_E_USG; }
 
   local _name _handler _desc _params _tags
-  local _applied=0 _skipped_tags=0 _skipped_handler=0 _skipped_optional=0
+  local _applied=0 _skipped_tags=0 _skipped_handler=0 _skipped_optional=0 _failed=0
   while IFS='|' read -r _name _handler _desc _params _tags || [[ -n "$_name" ]]; do
     _name="$(_manifest_trim "${_name:-}")"
     [[ -z "$_name" ]] && continue
@@ -565,17 +579,21 @@ _manifest_apply() {
       _add_args+=("${_kwargs[@]+"${_kwargs[@]}"}")
       if ! _cmd_add "$_normalized_handler" "$_name" "${_add_args[@]+"${_add_args[@]}"}" </dev/null; then
         u.warn "manifest: add failed for $_name - skipping row"
+        _failed=$((_failed + 1))
         continue
       fi
     fi
 
     if [[ "$(_get_package_status "$_name" </dev/null)" != "$_PKGMAN_STATUS_INSTALLED" ]]; then
-      _cmd_install "$_name" </dev/null || u.warn "manifest: install failed for $_name"
+      if ! _cmd_install "$_name" </dev/null; then u.warn "manifest: install failed for $_name"; _failed=$((_failed + 1)); continue; fi
     fi
     _applied=$((_applied + 1))
   done < "$_file"
 
-  u.info "✓ manifest applied: $_applied row(s) processed, $_skipped_tags filtered by tags, $_skipped_handler skipped (unknown handler), $_skipped_optional optional (not selected)"
+  u.info "✓ manifest applied: $_applied row(s) processed, $_skipped_tags filtered by tags, $_skipped_handler skipped (unknown handler), $_skipped_optional optional (not selected), $_failed failed"
+  # Automation contract: exit nonzero if any ATTEMPTED row failed (add/install), while still
+  # having attempted every other row. Skips (unknown handler / tag-filtered / optional) don't count.
+  [[ $_failed -gt 0 ]] && return $_E
   return 0
 }
 
@@ -634,7 +652,11 @@ _manifest_optional_names() {  # $1=file $2=os $3=host -> "name|desc" per optiona
 ##@ Usage: _manifest_sync <file> <os> <host> <prune:true|false>
 _manifest_sync() {
   local _file="$1" _os="$2" _host="$3" _prune="${4:-false}"
-  _manifest_apply "$_file" "$_os" "$_host" install || return $?
+  # Capture apply's result but DON'T abort: a failed install row doesn't change what's DECLARED,
+  # so prune (which removes undeclared packages) is still safe and should run. Surface the failure
+  # at the end. `|| _apply_rc=$?` also keeps set -e from tripping on the nonzero apply.
+  local _apply_rc=0
+  _manifest_apply "$_file" "$_os" "$_host" install || _apply_rc=$?
 
   local _declared="$(_manifest_declared_names "$_file" "$_os" "$_host")"
 
@@ -651,25 +673,26 @@ _manifest_sync() {
     _undeclared+=("$_pkg")
   done
 
+  # Every exit folds in _apply_rc so an install failure surfaces even when prune converged cleanly.
   if [[ ${#_undeclared[@]} -eq 0 ]]; then
     u.info "✓ sync: converged (nothing undeclared)"
-    return 0
+    return $_apply_rc
   fi
 
   u.warn "undeclared pkgman-managed package(s): ${_undeclared[*]}"
 
   if [[ "$_prune" != "true" ]]; then
     u.info "run again with --prune to remove them"
-    return 0
+    return $_apply_rc
   fi
 
-  _dry "prune: ${_undeclared[*]}" && return 0
+  _dry "prune: ${_undeclared[*]}" && return $_apply_rc
 
   if [[ "$_FORCE" != "true" ]]; then
-    loam.confirm "prune ${#_undeclared[@]} undeclared package(s): ${_undeclared[*]}?" || { u.info "prune cancelled"; return 0; }
+    loam.confirm "prune ${#_undeclared[@]} undeclared package(s): ${_undeclared[*]}?" || { u.info "prune cancelled"; return $_apply_rc; }
   fi
 
-  local _result=0
+  local _result=$_apply_rc
   for _pkg in "${_undeclared[@]}"; do
     if _cmd_uninstall "$_pkg" </dev/null && _cmd_remove "$_pkg" --force </dev/null; then
       u.info "✓ pruned $_pkg"
@@ -1663,10 +1686,10 @@ _cmd_add_unified() {
   # For traditional managers, default source to package name
   if [[ "$_source" == "default" ]]; then
     case "$_manager" in
-      brew|apt|dnf|mas|cargo|go|pipx|npm)
+      brew|apt|dnf|mas|cargo|go|pipx|npm|cask)
         _source="$_package"
         ;;
-      # github/download/script require explicit --source
+      # github/download/dmg/script require an explicit --source (URL/repo/path)
     esac
   fi
   
@@ -1677,12 +1700,13 @@ _cmd_add_unified() {
   [[ "$_artifact" != "default" ]] && _validation_kwargs+=("--artifact=$_artifact")
   [[ "$_channel" != "default" ]] && _validation_kwargs+=("--channel=$_channel")
   
-  # Add any additional kwargs
+  # Add any additional kwargs. Skip metadata-only keys (tags) so they don't leak into
+  # pkglib.*.validate, which never asks for them (#12: --tags leak into validate kwargs).
   local _i=0
   while [[ $_i -lt ${#_kwargs_keys[@]} ]]; do
     local _key="${_kwargs_keys[$_i]:-}"
     local _value="${_kwargs_values[$_i]:-}"
-    if [[ -n "$_key" && -n "$_value" ]]; then
+    if [[ -n "$_key" && -n "$_value" && "$_key" != "tags" ]]; then
       _validation_kwargs+=("--$_key=$_value")
     fi
     _i=$((_i + 1))
@@ -1691,7 +1715,9 @@ _cmd_add_unified() {
   # Always pass source as first parameter - pkglib needs the actual package identifier
   # shellcheck disable=SC2145  # legacy archive pattern, pre-loam
   u.debug "pkglib.${_manager}.validate - source=$_source, force=false, validation_kwargs=${_validation_kwargs[@]:-}"
-  pkglib.${_manager}.validate "$_source" "false" "${_validation_kwargs[@]:-}" || u.die "validation failed for $_manager package '$_package' with source '$_source'"
+  # Return (do NOT u.die): in manifest mode the caller skips this row and keeps going;
+  # a direct `add` still sees the nonzero exit. One bad row must never abort a whole manifest.
+  pkglib.${_manager}.validate "$_source" "false" "${_validation_kwargs[@]:-}" || { u.error "validation failed for $_manager package '$_package' with source '$_source'"; return $_E_USG; }
 
   # Store unified metadata (core parameters only) - SET SCOPE FIRST
   _set_metadata "$_package" "scope" "$_scope"

--- a/pkgman/tests.sh
+++ b/pkgman/tests.sh
@@ -94,7 +94,41 @@ test_tags_matcher() {
   assert_ok   $TOOL __tags-match 'mac,macmini'    mac macmini "host tag matches"
   assert_fail $TOOL __tags-match 'mac,laptop'     mac macmini "wrong host rejected"
   assert_ok   $TOOL __tags-match 'laptop,macmini' mac macmini "multi-host includes ours"
+  # host vocabulary is NOT hardcoded (#7): any host token works, `optional` is never a host
+  assert_ok   $TOOL __tags-match 'mac,bytepod'   mac bytepod  "arbitrary host tag (bytepod) matches"
+  assert_fail $TOOL __tags-match 'mac,bytepod'   mac laptop   "arbitrary host tag rejects a different host"
+  assert_ok   $TOOL __tags-match 'server'        linux server "bare host tag matches on right host"
+  assert_ok   $TOOL __tags-match 'mac,optional'  mac bytepod  "optional is a keyword, not a host filter"
+  assert_fail $TOOL __tags-match 'linux,edge'    linux server "unknown host 'edge' still filters (≠ server)"
   assert_eq 0 "$(grep -cE '(^|[^A-Za-z_])hostname([^A-Za-z_-]|$)' ./pkgman)" "no hostname derivation in pkgman"
+}
+
+test_cask_source_default() {
+  _section_header "#9: cask defaults source to the package name (no explicit source= needed)"
+  setup_cfg
+  assert_ok $TOOL add cask raycast --detail "launcher" "add cask with no --source succeeds"
+  assert_ok grep -q '^raycast.source=raycast' "$PKGMAN_CONFIG_DIR/index/package.core.cfg" "cask source defaulted to the name"
+}
+
+test_manifest_bad_row_skips_and_signals() {
+  _section_header "#8: an unusable row is skipped (run continues) AND the run exits nonzero"
+  setup_cfg
+  export MOCK_STATE; MOCK_STATE=$(mktemp -d "${TMPDIR:-/tmp}/mock-XXXXXX")
+  local _m; _m=$(mktemp "${TMPDIR:-/tmp}/badrow-manifest-XXXXXX")
+  # a github row missing required dest=/artifact= fails validation; a good script row follows it
+  printf 'ghbad | github | broken row | source=owner/repo | %s\ngood  | script | ok row | source=./mocks/mock-pkg!name=good | %s\n' "$THIS_OS" "$THIS_OS" > "$_m"
+  assert_fail $TOOL install "$_m" --host macmini "manifest with an unusable row exits nonzero (not u.die mid-run)"
+  assert_file_exists "$MOCK_STATE/good" "the good row AFTER the bad one still installed — the run was not aborted"
+  rm -f "$_m"
+}
+
+test_resolve_source_pkgman_dir() {
+  _section_header "#11: script source search includes pkgman's own dir (dogfood provision)"
+  # shellcheck disable=SC1091
+  source ./pkglib
+  local _p; _p=$(_pkglib.resolve_source_path pkgboot)
+  assert_contains "$_p" "/pkgboot" "resolves a script that lives beside pkgman itself"
+  assert_ok test -x "$_p" "resolved path is executable"
 }
 
 test_tags_metadata() {

--- a/pkgman/tests.sh
+++ b/pkgman/tests.sh
@@ -105,6 +105,8 @@ test_tags_matcher() {
 
 test_cask_source_default() {
   _section_header "#9: cask defaults source to the package name (no explicit source= needed)"
+  # cask is a macOS-only manager; `add cask` on linux correctly fails the OS-compat gate.
+  [[ "$(uname)" == "Darwin" ]] || return 0
   setup_cfg
   assert_ok $TOOL add cask raycast --detail "launcher" "add cask with no --source succeeds"
   assert_ok grep -q '^raycast.source=raycast' "$PKGMAN_CONFIG_DIR/index/package.core.cfg" "cask source defaulted to the name"


### PR DESCRIPTION
Fixes the tractable pkgman/pkglib follow-ups filed as #7–#12. **198 tests** (11 new), `make lint` + `make test` (6 tools) + shellcheck all green on bash 3.2 and 5.x.

## Fixed

- **#7 — `_tags_match` host vocabulary no longer hardcoded.** Was `laptop|macmini|server` (stale, and wrong for a generic tool). Now: OS tokens (`mac`/`linux`) filter by OS, `optional` is a reserved keyword, and **any other token is a host tag** — so `bytepod` or any future host works with no hardcoded list, while `optional` never acts as a host filter. New `__tags-match` cases cover both.
- **#8 — manifest row-failure handling.** (a) A validation failure now **warn+skips** the row instead of `u.die` aborting the whole manifest (the Track-B pain: one bad `github` row killed every row after it). (b) `_manifest_apply` counts *attempted-and-failed* rows (skips — unknown handler / tag-filtered / optional — don't count) and **exits nonzero** so an automating caller can tell a clean run from a partial one. `_manifest_sync` still prunes (a failed install doesn't change what's *declared*), then folds the failure into its exit code. New test: an unusable row is skipped, the good row after it still installs, and the run exits nonzero.
- **#9 — cask source-default.** `cask` joins the add-time name-default list, so a bare `appname | cask | … | | mac` row no longer tries to install a cask literally named `default`.
- **#11 — script source-search includes pkgman's own dir**, so a self-hosted/dogfood provision resolves script rows (e.g. `pkgboot`) that live beside pkgman.
- **#12a — `--tags` no longer leaks into `pkglib.*.validate` kwargs** (harmless before — validators ignore unknown kwargs — but now clean). **#12c** (temp-dir traps) was already handled at both `mktemp` sites.

## Deferred (need focused design — noted on the issues)

- **#12b** `_cmd_uninstall` stale-status reconciliation and **#12d** `install <name>`-vs-`<file>` routing: both are behavior-change-risky and deserve their own pass, not a rushed edit bundled here.
- **#10** loam trim: large, and deliberately deferred per radix's `reference/decisions.md`.