### PR TITLE
feat(pkgman): upgrade-deps — the dependency tier as an optional capability

### DIFF
--- a/pkgman/pkglib
+++ b/pkgman/pkglib
@@ -408,6 +408,20 @@ pkglib.common.update() {
   return 0
 }
 
+##@ Does this manager have a separate DEPENDENCY TIER - transitive packages it installs alongside what
+##@ you asked for, which can go outdated and be upgraded INDEPENDENTLY? True only for the system package
+##@ managers. The language managers (npm/pipx/cargo/go) vendor deps INSIDE the package, so upgrading the
+##@ package already covers them; mas/cask/github/download/dmg/script install self-contained artifacts
+##@ with no dependency tier at all. This is why upgrade-deps is an OPTIONAL capability rather than a 6th
+##@ required operation: forcing all 13 handlers to implement it would be false symmetry.
+##: pkglib.common.has_dep_tier <manager> -> if pkglib.common.has_dep_tier brew; then ...
+pkglib.common.has_dep_tier() {
+  case "${1:-}" in
+    brew|apt|dnf) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 ##@ common uninstall flow
 ##: pkglib.common.uninstall <manager> <name> <force> [--key=value...] -> pkglib.common.uninstall brew docker false --cask
 pkglib.common.uninstall() {
@@ -515,6 +529,24 @@ pkglib.brew.update() {
 ##: pkglib.brew.uninstall <name> <force> [--key=value...] -> pkglib.brew.uninstall docker false --cask
 pkglib.brew.uninstall() {
   pkglib.common.uninstall "brew" "$@"
+}
+
+##@ brew dependency-tier upgrade (OPTIONAL capability - see pkglib.common.has_dep_tier).
+##@ Upgrades software this manager installed as transitive DEPENDENCIES, which a manifest never
+##@ declares (only top-level intent is declared). With names, upgrades just those; bare, sweeps all
+##@ outdated formulae. NOTE: brew resolves its own graph, so this is inherently coarser than a
+##@ declared-row upgrade - it may pull related packages along. Caller surfaces that.
+##: pkglib.brew.upgrade_deps [name...] -> pkglib.brew.upgrade_deps openssl ca-certificates
+pkglib.brew.upgrade_deps() {
+  _pkglib.require_tool "brew" || return $_E_DEP
+  if [[ $# -gt 0 ]]; then
+    _debug "brew upgrade $*"
+    brew upgrade "$@" || { _error "brew upgrade failed: $*"; return $_E; }
+  else
+    _debug "brew upgrade (all outdated, incl. dependencies)"
+    brew upgrade || { _error "brew upgrade failed"; return $_E; }
+  fi
+  return 0
 }
 ##] brew
 
@@ -704,6 +736,20 @@ pkglib.apt.status() {
   dpkg -l "$_name" &>/dev/null && echo "$_PKGLIB_STATUS_INSTALLED" || echo "$_PKGLIB_STATUS_MISSING"
   return 0
 }
+
+##@ apt dependency-tier upgrade (OPTIONAL capability - see pkglib.common.has_dep_tier)
+##: pkglib.apt.upgrade_deps [name...] -> pkglib.apt.upgrade_deps libssl3
+pkglib.apt.upgrade_deps() {
+  _pkglib.require_tool "apt-get" || return $_E_DEP
+  if [[ $# -gt 0 ]]; then
+    _debug "apt-get install --only-upgrade -y $*"
+    apt-get install --only-upgrade -y "$@" || { _error "apt-get upgrade failed: $*"; return $_E; }
+  else
+    _debug "apt-get upgrade -y (all outdated, incl. dependencies)"
+    apt-get upgrade -y || { _error "apt-get upgrade failed"; return $_E; }
+  fi
+  return 0
+}
 ##] apt
 
 ##[ dnf
@@ -801,6 +847,20 @@ pkglib.dnf.status() {
   # Action - status checking doesn't need kwargs
   _debug "dnf list installed $_name"
   dnf list installed "$_name" &>/dev/null && echo "$_PKGLIB_STATUS_INSTALLED" || echo "$_PKGLIB_STATUS_MISSING"
+  return 0
+}
+
+##@ dnf dependency-tier upgrade (OPTIONAL capability - see pkglib.common.has_dep_tier)
+##: pkglib.dnf.upgrade_deps [name...] -> pkglib.dnf.upgrade_deps openssl-libs
+pkglib.dnf.upgrade_deps() {
+  _pkglib.require_tool "dnf" || return $_E_DEP
+  if [[ $# -gt 0 ]]; then
+    _debug "dnf upgrade -y $*"
+    dnf upgrade -y "$@" || { _error "dnf upgrade failed: $*"; return $_E; }
+  else
+    _debug "dnf upgrade -y (all outdated, incl. dependencies)"
+    dnf upgrade -y || { _error "dnf upgrade failed"; return $_E; }
+  fi
   return 0
 }
 ##] dnf

--- a/pkgman/pkgman
+++ b/pkgman/pkgman
@@ -271,6 +271,16 @@ _main() {
       u.error "upgrade needs a manifest (upgrade <manifest> --host <h>); for one tracked package use: $__APP update <name>"
       exit $_E_USG
       ;;
+    upgrade-deps)
+      if [[ -f "${1:-}" ]]; then
+        # Dependency tier: software a manager pulled in transitively, which a manifest never declares.
+        [[ -n "$_HOST" ]] || { u.error "--host required for manifest mode (upgrade-deps <manifest> --host <h>)"; exit $_E_USG; }
+        _manifest_upgrade_deps "$1" "$(loam.os)" "$_HOST"
+        exit $?
+      fi
+      u.error "upgrade-deps needs a manifest (upgrade-deps <manifest> --host <h> [--only=<csv>])"
+      exit $_E_USG
+      ;;
     # Batch operations
     install-all) _cmd_install_all "$@" ;;
     sync-all) _cmd_sync_all "$@" ;;
@@ -722,6 +732,76 @@ _manifest_upgrade() {
     u.warn "--only=$_ONLY matched no upgradable row (check the name, and that it is declared + installed)"
   fi
   # Automation contract (mirrors _manifest_apply): nonzero iff an attempted upgrade failed.
+  [[ $_failed -gt 0 ]] && return $_E
+  return 0
+}
+
+##@ Upgrade the DEPENDENCY TIER: software a manager installed transitively (as a dependency of something
+##@ declared) and that the manifest therefore never names - a manifest declares top-level INTENT, not the
+##@ resolved graph. This is the companion to `upgrade`, which is manifest-scoped and so structurally
+##@ cannot reach these. Which managers are in play is derived FROM the manifest (the handlers its
+##@ applicable rows use), so this stays declaration-driven rather than hardcoding a package manager.
+##@ Only managers with a real dependency tier act (pkglib.common.has_dep_tier: brew/apt/dnf); the rest
+##@ report an honest no-op instead of pretending. With --only=<csv>, upgrades just those dependency
+##@ names. CAVEAT surfaced to the caller: a system package manager resolves its own graph, so this is
+##@ inherently coarser than a declared-row upgrade - it may pull related packages along.
+##@ Usage: _manifest_upgrade_deps <file> <os> <host>
+_manifest_upgrade_deps() {
+  local _file="$1" _os="$2" _host="$3"
+  [[ -f "$_file" ]] || { u.error "manifest not found: $_file"; return $_E_NF; }
+
+  # Which managers does this manifest actually use on this host? (dedup, order-preserving; bash 3.2:
+  # a space-padded string membership test, no associative arrays.)
+  # NB: collected into an ARRAY, not a space-joined string - this script runs with the secure
+  # IFS=$'\n\t' (line 21), under which `for m in $space_joined` would not word-split at all.
+  local _name _handler _desc _params _tags _norm _seen=" " _mgr_arr=()
+  while IFS='|' read -r _name _handler _desc _params _tags || [[ -n "$_name" ]]; do
+    _name="$(_manifest_trim "${_name:-}")"
+    [[ -z "$_name" ]] && continue
+    case "$_name" in \#*) continue ;; esac
+    _handler="$(_manifest_trim "${_handler:-}")"
+    _tags="$(_manifest_trim "${_tags:-}")"
+    _tags_match "$_tags" "$_os" "$_host" </dev/null || continue
+    _norm="$(_normalize_and_validate_manager "$_handler" 2>/dev/null </dev/null)" || continue
+    case "$_seen" in *" $_norm "*) continue ;; esac
+    _seen="$_seen$_norm "
+    _mgr_arr+=("$_norm")
+  done < "$_file"
+  [[ ${#_mgr_arr[@]} -eq 0 ]] && { u.info "no applicable manifest rows - nothing to do"; return 0; }
+
+  # --only names are dependency package names here (NOT manifest rows), so they are passed straight to
+  # the manager. A dependency is by definition undeclared, so there is nothing to validate them against.
+  local _only_args=() _o
+  if [[ -n "$_ONLY" ]]; then
+    local _oldifs="$IFS"; IFS=','
+    # shellcheck disable=SC2086  # deliberate word splitting of the csv
+    set -- ${_ONLY// /}
+    IFS="$_oldifs"
+    for _o in "$@"; do [[ -n "$_o" ]] && _only_args+=("$_o"); done
+  fi
+
+  local _acted=0 _noop=0 _failed=0 _m
+  for _m in "${_mgr_arr[@]}"; do
+    if ! pkglib.common.has_dep_tier "$_m"; then
+      u.debug "no dependency tier for $_m (deps are vendored or artifacts are self-contained) - skipping"
+      _noop=$((_noop + 1)); continue
+    fi
+    # Join for DISPLAY with an explicit space: under the secure IFS=$'\n\t', "${arr[*]}" would join
+    # with a newline and the message would read as several broken lines.
+    local _what="all outdated dependencies" _join="" _a
+    for _a in "${_only_args[@]+"${_only_args[@]}"}"; do _join="${_join:+$_join }$_a"; done
+    [[ -n "$_join" ]] && _what="$_join"
+    if ! _dry "pkglib.$_m.upgrade_deps ${_join:-<all>}"; then
+      u.info "upgrading $_m dependency tier: $_what"
+      if "pkglib.$_m.upgrade_deps" "${_only_args[@]+"${_only_args[@]}"}"; then _acted=$((_acted + 1))
+      else u.warn "dependency upgrade failed for $_m"; _failed=$((_failed + 1)); fi
+    else
+      _acted=$((_acted + 1))
+    fi
+  done
+
+  u.info "✓ dependency tier: $_acted manager(s) upgraded, $_noop with no dependency tier, $_failed failed"
+  [[ $_acted -gt 0 ]] && u.warn "the dependency tier is NOT manifest-scoped: a package manager resolves its own graph, so related packages may have been upgraded too"
   [[ $_failed -gt 0 ]] && return $_E
   return 0
 }
@@ -2281,6 +2361,11 @@ COMMANDS:
                                         (a hold= param skips the row - upgrade it deliberately).
                                         --only=<csv> upgrades just those rows (targeted CVE response);
                                         naming a held row there overrides its hold
+    upgrade-deps <manifest> --host <h> [--only=<csv>]
+                                        Upgrade the DEPENDENCY tier: software pulled in transitively by
+                                        the manifest's managers, which a manifest never declares. Only
+                                        managers with a real dependency tier act (brew/apt/dnf); others
+                                        no-op. NOT manifest-scoped - the manager resolves its own graph.
 
     # Batch Operations  
     install-all [--force]               Install all missing tracked packages (core scope only)

--- a/pkgman/tests.sh
+++ b/pkgman/tests.sh
@@ -467,4 +467,43 @@ test_manifest_upgrade_only() {
   rm -f "$_m"
 }
 
+test_upgrade_deps() {
+  _section_header "P1: upgrade-deps — dependency tier (optional per-manager capability, honest no-ops)"
+  setup_cfg
+  # shellcheck disable=SC1091
+  source ./pkglib
+  # the capability predicate is the contract: only system package managers have a dependency tier
+  assert_ok pkglib.common.has_dep_tier brew "brew has a dependency tier"
+  assert_ok pkglib.common.has_dep_tier apt  "apt has a dependency tier"
+  assert_ok pkglib.common.has_dep_tier dnf  "dnf has a dependency tier"
+  for _m in npm pipx cargo go mas cask github download dmg script; do
+    assert_fail pkglib.common.has_dep_tier "$_m" "$_m has NO dependency tier (deps vendored / self-contained)"
+  done
+
+  # a script-handler-only manifest => no manager with a dep tier => honest no-op, still exit 0
+  export MOCK_STATE; MOCK_STATE=$(mktemp -d "${TMPDIR:-/tmp}/mock-XXXXXX")
+  local _m2; _m2=$(mktemp "${TMPDIR:-/tmp}/deps-XXXXXX")
+  printf 'one | script | mock 1 | source=%s/mocks/mock-pkg!name=one | \n' "$PWD" > "$_m2"
+  local out; out=$($TOOL upgrade-deps "$_m2" --host macmini 2>&1)
+  assert_ok $TOOL upgrade-deps "$_m2" --host macmini "upgrade-deps exits 0 with no dep-tier manager"
+  assert_contains "$out" "no dependency tier" "reports the honest no-op rather than pretending"
+  assert_contains "$out" "0 manager(s) upgraded" "nothing was upgraded"
+
+  # a brew row => brew acts; --dry-run plans the per-manager call without running it
+  local _m3; _m3=$(mktemp "${TMPDIR:-/tmp}/deps2-XXXXXX")
+  printf 'somepkg | brew | b | | \n' > "$_m3"
+  out=$($TOOL --dry-run upgrade-deps "$_m3" --host macmini 2>&1)
+  assert_contains "$out" "pkglib.brew.upgrade_deps" "dry-run plans the brew dependency upgrade"
+  assert_contains "$out" "1 manager(s)" "the dep-tier manager is counted"
+  assert_contains "$out" "NOT manifest-scoped" "surfaces that the dep tier is coarser (manager resolves its own graph)"
+  # --only names are dependency names passed straight through (they are undeclared by definition)
+  out=$($TOOL --dry-run upgrade-deps "$_m3" --host macmini --only=openssl,ca-certificates 2>&1)
+  assert_contains "$out" "openssl ca-certificates" "targeted dep names passed through (space-joined for display)"
+  # guardrails
+  assert_fail $TOOL upgrade-deps "$_m3" "upgrade-deps without --host fails"
+  assert_fail $TOOL upgrade-deps not-a-file --host macmini "upgrade-deps without a manifest fails"
+
+  rm -f "$_m2" "$_m3"
+}
+
 _test_runner


### PR DESCRIPTION
A manifest declares top-level **intent**, not the resolved graph — so `upgrade` (manifest-scoped by design) structurally cannot reach software a manager pulled in transitively. On a real fleet that is exactly where most CVEs land: **6 of 8 security-flagged packages on a live host were brew dependencies, not declared rows.**

`pkgman upgrade-deps <manifest> --host <h> [--only=<csv>]` closes that gap without weakening the manifest-scoped guarantee that makes `upgrade` / `sync --prune` safe. It derives *which* managers are in play from the manifest's applicable rows (declaration-driven, not hardcoded to brew), then delegates per manager.

## General in shape, not brew-specific

Implemented as an **optional pkglib capability** (`pkglib.<mgr>.upgrade_deps`, gated by `pkglib.common.has_dep_tier`) rather than a 6th required entry in `PKGMAN_OPERATIONS` — forcing all 13 handlers to implement it would be false symmetry:

| managers | dependency tier? |
|---|---|
| brew / apt / dnf | **yes** → implemented (apt + dnf drop in free for a Linux host) |
| npm / pipx / cargo / go | no — deps vendored *inside* the package |
| mas / cask / github / download / dmg / script | no — self-contained artifacts |

Managers without the tier report an **honest no-op** instead of pretending.

`--only` names here are *dependency* names (undeclared by definition), passed straight to the manager. The command **warns that this tier is NOT manifest-scoped** — a system package manager resolves its own graph, so related packages may come along.

## Also fixes a latent trap

This script runs with the secure `IFS=$'\n\t'` (line 21), under which `for m in $space_joined` does **not** word-split at all. Manager collection now uses an array; display joins explicitly.

## Tests

`test_upgrade_deps` — capability matrix across all 13 handlers, honest no-op, brew acts, dry-run, targeted `--only` passthrough, guardrails. 246 tests; full monorepo lint + test green on macOS bash 3.2.
