### PR TITLE
feat(pkgman): adopt — reverse-sync installed packages into manifest rows

### DIFF
--- a/pkgman/pkglib
+++ b/pkgman/pkglib
@@ -408,6 +408,97 @@ pkglib.common.update() {
   return 0
 }
 
+##@ Can this manager ENUMERATE what it has installed, so `adopt` can reverse-sync it into a manifest?
+##@ Optional capability, like has_dep_tier - not every handler can answer "what did you install?"
+##@ (github/download/dmg/script place arbitrary artifacts; pkgman's own tracking is their only record).
+##: pkglib.common.can_list_installed <manager> -> if pkglib.common.can_list_installed brew; then ...
+pkglib.common.can_list_installed() {
+  case "${1:-}" in
+    brew|cask|mas|pipx|npm|apt|dnf) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+##@ List TOP-LEVEL installed packages, one per line, as: name<TAB>source<TAB>desc (source/desc may be
+##@ empty). TOP-LEVEL is the point: a manifest declares INTENT, so `adopt` must offer only what was
+##@ deliberately installed, never the transitive dependency closure (on a real box that is 275 formulae
+##@ vs 71 leaves). Dependencies belong to the upgrade-deps tier, not to the manifest.
+##: pkglib.brew.list_installed -> jq
+pkglib.brew.list_installed() {
+  _pkglib.require_tool "brew" || return $_E_DEP
+  # `leaves` = installed formulae nothing else depends on = what the user actually asked for
+  brew leaves 2>/dev/null | while IFS= read -r _n; do [[ -n "$_n" ]] && printf '%s\t\t\n' "$_n"; done
+  return 0
+}
+
+##: pkglib.cask.list_installed -> raycast<TAB>raycast
+pkglib.cask.list_installed() {
+  _pkglib.require_tool "brew" || return $_E_DEP
+  # casks are always top-level (nothing depends on a cask); source= is the cask token itself
+  brew list --cask 2>/dev/null | while IFS= read -r _n; do [[ -n "$_n" ]] && printf '%s\t%s\t\n' "$_n" "$_n"; done
+  return 0
+}
+
+##: pkglib.mas.list_installed -> keynote<TAB>409183694<TAB>Keynote
+pkglib.mas.list_installed() {
+  _pkglib.require_tool "mas" || return $_E_DEP
+  # `mas list` prints "<id>  <App Name>  (<version>)"; the name may contain spaces, so strip the
+  # trailing "(version)" and take everything after the id. Row name = a slug of the app name.
+  mas list 2>/dev/null | while IFS= read -r _line; do
+    [[ -z "$_line" ]] && continue
+    local _id _rest _nm _slug
+    _id="$(printf '%s' "$_line" | awk '{print $1}')"
+    [[ -z "$_id" ]] && continue
+    _rest="${_line#*"$_id"}"
+    _nm="$(printf '%s' "$_rest" | sed -e 's/[[:space:]]*([^()]*)[[:space:]]*$//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    _slug="$(printf '%s' "$_nm" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')"
+    [[ -n "$_slug" ]] && printf '%s\t%s\t%s\n' "$_slug" "$_id" "$_nm"
+  done
+  return 0
+}
+
+##: pkglib.pipx.list_installed -> fastapi-clean-cli
+pkglib.pipx.list_installed() {
+  _pkglib.require_tool "pipx" || return $_E_DEP
+  # `pipx list --short` prints "<pkg> <version>"; every pipx app is top-level by construction
+  pipx list --short 2>/dev/null | while IFS= read -r _line; do
+    local _n; _n="$(printf '%s' "$_line" | awk '{print $1}')"
+    [[ -n "$_n" ]] && printf '%s\t\t\n' "$_n"
+  done
+  return 0
+}
+
+##: pkglib.npm.list_installed -> typescript
+pkglib.npm.list_installed() {
+  _pkglib.require_tool "npm" || return $_E_DEP
+  # `npm ls -g --depth=0` prints a tree; take each "pkg@version" leaf and strip the LAST @ (scoped
+  # names like @openai/codex legitimately start with one). npm itself is excluded - it is the manager.
+  npm ls -g --depth=0 2>/dev/null | sed -n 's/^[^a-zA-Z@]*\([@a-zA-Z].*\)$/\1/p' | while IFS= read -r _spec; do
+    [[ -z "$_spec" ]] && continue
+    # Every real entry is "pkg@version"; the tree's first line is the lib ROOT PATH (no '@') - drop it.
+    case "$_spec" in *@*) ;; *) continue ;; esac
+    local _n="${_spec%@*}"
+    [[ -z "$_n" || "$_n" == "npm" ]] && continue
+    printf '%s\t\t\n' "$_n"
+  done
+  return 0
+}
+
+##: pkglib.apt.list_installed -> nginx
+pkglib.apt.list_installed() {
+  _pkglib.require_tool "apt-mark" || return $_E_DEP
+  # showmanual = explicitly installed, excluding anything pulled in as a dependency
+  apt-mark showmanual 2>/dev/null | while IFS= read -r _n; do [[ -n "$_n" ]] && printf '%s\t\t\n' "$_n"; done
+  return 0
+}
+
+##: pkglib.dnf.list_installed -> nginx
+pkglib.dnf.list_installed() {
+  _pkglib.require_tool "dnf" || return $_E_DEP
+  dnf repoquery --userinstalled --qf '%{name}\n' 2>/dev/null | while IFS= read -r _n; do [[ -n "$_n" ]] && printf '%s\t\t\n' "$_n"; done
+  return 0
+}
+
 ##@ Does this manager have a separate DEPENDENCY TIER - transitive packages it installs alongside what
 ##@ you asked for, which can go outdated and be upgraded INDEPENDENTLY? True only for the system package
 ##@ managers. The language managers (npm/pipx/cargo/go) vendor deps INSIDE the package, so upgrading the

--- a/pkgman/pkgman
+++ b/pkgman/pkgman
@@ -121,6 +121,9 @@ _INSTALL_OPTIONALS=""
 # Targeted upgrades are the CVE-response shape ("patch just openssl now"), and an explicitly named row
 # OVERRIDES its hold (naming it IS the deliberate act a hold asks for).
 _ONLY=""
+# adopt scope: --all offers every undeclared top-level package; --tags stamps the emitted rows.
+_ALL=false
+_TAGS=""
 
 # Status constants
 readonly _PKGMAN_STATUS_INSTALLED="installed"
@@ -193,6 +196,23 @@ _main() {
         ;;
       --only=*)
         _ONLY="${1#*=}"
+        shift
+        ;;
+      --all)
+        _ALL=true
+        shift
+        ;;
+      --tags)
+        # Global MIRROR of the per-command --tags (consumed by `adopt` to stamp emitted rows). Left in
+        # _args too so `add --tags <v>` keeps seeing it - same additive pattern as --force below.
+        [[ -n "${2:-}" && "$2" != "--"* ]] || { u.error "--tags requires a value"; exit $_E_USG; }
+        _TAGS="$2"
+        _args+=("$1" "$2")
+        shift 2
+        ;;
+      --tags=*)
+        _TAGS="${1#*=}"
+        _args+=("$1")
         shift
         ;;
       --force)
@@ -279,6 +299,19 @@ _main() {
         exit $?
       fi
       u.error "upgrade-deps needs a manifest (upgrade-deps <manifest> --host <h> [--only=<csv>])"
+      exit $_E_USG
+      ;;
+    adopt)
+      # REVERSE-SYNC (no --host: host-agnostic by design - see _manifest_adopt)
+      if [[ -f "${1:-}" ]]; then
+        local _adopt_manifest="$1" _adopt_names=""; shift
+        # --tags is re-added to _args (so `add` still sees it), so a flag can appear where the optional
+        # name/csv would be - take the next arg as names ONLY when it is not a flag.
+        case "${1:-}" in --*|"") ;; *) _adopt_names="$1" ;; esac
+        _manifest_adopt "$_adopt_manifest" "$_adopt_names" "$_ALL" "$_TAGS"
+        exit $?
+      fi
+      u.error "adopt needs a manifest (adopt <manifest> [<name>|<csv>] [--all] [--tags=<csv>])"
       exit $_E_USG
       ;;
     # Batch operations
@@ -803,6 +836,63 @@ _manifest_upgrade_deps() {
   u.info "✓ dependency tier: $_acted manager(s) upgraded, $_noop with no dependency tier, $_failed failed"
   [[ $_acted -gt 0 ]] && u.warn "the dependency tier is NOT manifest-scoped: a package manager resolves its own graph, so related packages may have been upgraded too"
   [[ $_failed -gt 0 ]] && return $_E
+  return 0
+}
+
+##@ REVERSE-SYNC: emit manifest rows for installed packages the manifest does NOT declare. The inverse
+##@ of `sync --prune`: same discovery ("installed but undeclared"), opposite resolution - prune EVICTS
+##@ the stray, adopt DECLARES it. Prints rows to STDOUT and never writes the manifest (pkgman does not
+##@ own a file it merely ingests; a caller that owns it appends and diffs). Only TOP-LEVEL packages are
+##@ offered (pkglib.<mgr>.list_installed) - a manifest declares INTENT, so the transitive dependency
+##@ closure must never be adopted into it.
+##@ Deliberately host-AGNOSTIC: dedupe is against EVERY declared row regardless of tags (a row declared
+##@ for another machine is still declared, and re-emitting it would duplicate), and the new rows' tags
+##@ come from --tags. So --host would be meaningless here, unlike install/sync/upgrade which must decide
+##@ which declared rows apply to THIS machine.
+##@ Usage: _manifest_adopt <file> <names-csv|""> <all:true|false> <tags>
+_manifest_adopt() {
+  local _file="$1" _names="${2:-}" _all="${3:-false}" _tags="${4:-}"
+  [[ -f "$_file" ]] || { u.error "manifest not found: $_file"; return $_E_NF; }
+  [[ "$_all" == "true" || -n "$_names" ]] || { u.error "adopt: name a package (or a csv), or pass --all"; return $_E_USG; }
+
+  # 1. every declared name, tags ignored (see above)
+  local _dn _dh _dd _dp _dt _declared=" "
+  while IFS='|' read -r _dn _dh _dd _dp _dt || [[ -n "$_dn" ]]; do
+    _dn="$(_manifest_trim "${_dn:-}")"
+    [[ -z "$_dn" ]] && continue
+    case "$_dn" in \#*) continue ;; esac
+    _declared="$_declared$_dn "
+  done < "$_file"
+
+  # 2. walk every manager that can enumerate itself, emitting undeclared top-level packages
+  local _mgr _n _src _desc _emitted=0 _skipped=0 _found=" "
+  local _wanted=" ${_names//,/ } "
+  for _mgr in "${PKGMAN_MANAGERS[@]:-}"; do
+    pkglib.common.can_list_installed "$_mgr" || continue
+    command -v "$(_pkglib.manager_tool "$_mgr")" >/dev/null 2>&1 || continue
+    while IFS=$'\t' read -r _n _src _desc || [[ -n "$_n" ]]; do
+      [[ -z "$_n" ]] && continue
+      if [[ "$_all" != "true" ]]; then
+        case "$_wanted" in *" $_n "*) ;; *) continue ;; esac
+      fi
+      _found="$_found$_n "
+      case "$_declared" in *" $_n "*) _skipped=$((_skipped + 1)); continue ;; esac
+      printf '%-14s | %-4s | %-30s | %-24s | %s\n' \
+        "$_n" "$_mgr" "${_desc:-$_n}" "${_src:+source=$_src}" "$_tags"
+      _emitted=$((_emitted + 1))
+    done < <("pkglib.$_mgr.list_installed" 2>/dev/null || true)
+  done
+
+  # 3. a requested name installed nowhere is almost certainly a typo - never fail silently
+  if [[ "$_all" != "true" ]]; then
+    local _w
+    for _w in ${_names//,/ }; do
+      [[ -z "$_w" ]] && continue
+      case "$_found" in *" $_w "*) ;; *) u.warn "not installed by any manager pkgman can enumerate: $_w" ;; esac
+    done
+  fi
+  # counters to stderr so stdout stays a clean, appendable stream of manifest rows
+  u.info "✓ adopt: $_emitted row(s) emitted, $_skipped already declared" >&2
   return 0
 }
 
@@ -2361,6 +2451,11 @@ COMMANDS:
                                         (a hold= param skips the row - upgrade it deliberately).
                                         --only=<csv> upgrades just those rows (targeted CVE response);
                                         naming a held row there overrides its hold
+    adopt <manifest> [<name>|<csv>] [--all] [--tags=<csv>]
+                                        REVERSE-SYNC: print manifest rows for installed TOP-LEVEL
+                                        packages the manifest does not declare (inverse of sync
+                                        --prune). Writes nothing - redirect or let a caller append.
+                                        Host-agnostic: dedupes against ALL declared rows.
     upgrade-deps <manifest> --host <h> [--only=<csv>]
                                         Upgrade the DEPENDENCY tier: software pulled in transitively by
                                         the manifest's managers, which a manifest never declares. Only

--- a/pkgman/tests.sh
+++ b/pkgman/tests.sh
@@ -506,4 +506,62 @@ test_upgrade_deps() {
   rm -f "$_m2" "$_m3"
 }
 
+test_adopt() {
+  _section_header "P1: adopt — reverse-sync installed packages into manifest rows"
+  setup_cfg
+  # shellcheck disable=SC1091
+  source ./pkglib
+  # enumeration is an optional capability: artifact handlers cannot answer "what did you install?"
+  assert_ok pkglib.common.can_list_installed brew "brew can enumerate installed packages"
+  assert_ok pkglib.common.can_list_installed mas  "mas can enumerate"
+  for _m in github download dmg script cargo go; do
+    assert_fail pkglib.common.can_list_installed "$_m" "$_m cannot enumerate (no reliable inventory)"
+  done
+
+  # fake brew: 'leaves' (TOP-LEVEL only) is what adopt must consume - never the full formula list
+  local _fake; _fake=$(mktemp -d "${TMPDIR:-/tmp}/fakebin-XXXXXX")
+  cat > "$_fake/brew" <<'EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "leaves")           printf 'declared-pkg\nstray-pkg\n' ;;
+  "list --cask")      printf 'stray-cask\n' ;;
+  "list --formula")   printf 'declared-pkg\nstray-pkg\nsome-dependency\n' ;;
+esac
+exit 0
+EOF
+  chmod +x "$_fake/brew"
+
+  local _m; _m=$(mktemp "${TMPDIR:-/tmp}/adopt-XXXXXX")
+  printf '# comment row\ndeclared-pkg | brew | already there | | mac\n' > "$_m"
+
+  local out; out=$(PATH="$_fake:/usr/bin:/bin" $TOOL adopt "$_m" --all 2>&1)
+  assert_contains "$out" "stray-pkg" "undeclared installed package is emitted"
+  assert_contains "$out" "stray-cask" "undeclared cask is emitted with its handler"
+  assert_eq 0 "$(printf '%s\n' "$out" | grep -c '^declared-pkg' || true)" "already-declared package is NOT re-emitted"
+  assert_eq 0 "$(printf '%s\n' "$out" | grep -c 'some-dependency' || true)" "DEPENDENCY not offered (only top-level: leaves, not list --formula)"
+  assert_contains "$out" "already declared" "summary reports the skipped count"
+  # emitted row is a valid manifest row: name|handler|desc|params|tags, and cask carries source=
+  assert_contains "$out" "| cask |" "cask row names the cask handler"
+  assert_contains "$out" "source=stray-cask" "cask row carries source="
+
+  # csv/single selection + --tags stamping
+  out=$(PATH="$_fake:/usr/bin:/bin" $TOOL adopt "$_m" stray-pkg --tags=mac,laptop 2>&1)
+  assert_contains "$out" "stray-pkg" "named package emitted"
+  assert_contains "$out" "mac,laptop" "--tags stamps the emitted row"
+  assert_eq 0 "$(printf '%s\n' "$out" | grep -c 'stray-cask' || true)" "unnamed package not emitted when a name is given"
+
+  # a name that is installed nowhere warns (typo guard), and no-args is a usage error
+  out=$(PATH="$_fake:/usr/bin:/bin" $TOOL adopt "$_m" nosuchthing 2>&1)
+  assert_contains "$out" "not installed by any manager" "unknown name warns rather than silently emitting nothing"
+  assert_fail env PATH="$_fake:$PATH" $TOOL adopt "$_m" "adopt with neither a name nor --all fails"
+  assert_fail $TOOL adopt not-a-file --all "adopt without a manifest fails"
+
+  # stdout must stay a clean appendable stream: counters go to stderr
+  local rows; rows=$(PATH="$_fake:/usr/bin:/bin" $TOOL adopt "$_m" --all 2>/dev/null)
+  assert_eq 0 "$(printf '%s\n' "$rows" | grep -c 'adopt:' || true)" "stdout carries only rows (summary is on stderr)"
+  assert_eq 2 "$(printf '%s\n' "$rows" | grep -c '|' || true)" "stdout is exactly the two undeclared rows"
+
+  rm -rf "$_fake"; rm -f "$_m"
+}
+
 _test_runner

--- a/pkgman/tests.sh
+++ b/pkgman/tests.sh
@@ -530,6 +530,13 @@ esac
 exit 0
 EOF
   chmod +x "$_fake/brew"
+  # HERMETIC: shadow every OTHER enumerable manager's tool with a silent no-op. Without this the suite
+  # inherits the host's real inventory — on the ubuntu CI lane `apt-mark showmanual` alone contributed
+  # 251 rows, and on macOS mas/npm/pipx did the same. Only the fake brew may produce rows here.
+  local _t
+  for _t in mas pipx npm apt-mark dnf; do
+    printf '#!/usr/bin/env bash\nexit 0\n' > "$_fake/$_t"; chmod +x "$_fake/$_t"
+  done
 
   local _m; _m=$(mktemp "${TMPDIR:-/tmp}/adopt-XXXXXX")
   printf '# comment row\ndeclared-pkg | brew | already there | | mac\n' > "$_m"


### PR DESCRIPTION
The inverse of `sync --prune`: **same discovery** ("installed but undeclared"), **opposite resolution** — prune *evicts* the stray, `adopt` *declares* it.

```
pkgman adopt <manifest> [<name>|<csv>] [--all] [--tags=<csv>]
```

Emits ready-to-paste manifest rows to **stdout** and never writes the manifest — pkgman does not own a file it merely ingests; a caller that owns it appends and diffs. Counters go to stderr so stdout stays a clean appendable stream.

## Top-level only

A manifest declares **intent**, not the resolved graph — so `adopt` offers only what was deliberately installed, never the transitive dependency closure. On a real box that is **71 `brew leaves` vs 275 formulae**. Dependencies belong to the `upgrade-deps` tier, not the manifest. This is the same declared/dependency split introduced in #16, applied in reverse.

## Host-agnostic by design

Unlike `install`/`sync`/`upgrade`, `adopt` takes **no `--host`**: dedupe runs against *every* declared row regardless of tags (a row declared for another machine is still declared — re-emitting it would duplicate), and the new rows' tags come from `--tags`. Tag filtering would be actively wrong here.

## Enumeration is an optional capability

`pkglib.common.can_list_installed` + `pkglib.<mgr>.list_installed`, mirroring `has_dep_tier` from #16 — not every handler can answer "what did you install?":

| managers | enumerable? |
|---|---|
| brew (`leaves`) / cask / mas / pipx / npm / apt (`showmanual`) / dnf (`--userinstalled`) | **yes** |
| github / download / dmg / script / cargo / go | no — arbitrary artifacts; pkgman's own tracking is their only record |

Handlers carry their own row shape: cask emits `source=<token>`, mas emits `source=<app-id>` with the App Store name as the description and a slug as the row name.

## Also fixes

- **`--tags` regression**: the new global flag was swallowing `add --tags <v>`. Now mirrored into `_args` (the same additive pattern `--force` already uses) so per-command parsing is unaffected — caught by the existing `test_tags_metadata`.
- **npm lister**: `npm ls -g --depth=0` prints the lib root path as its first line; entries are now required to contain `@`.

## Tests

`test_adopt` — capability matrix, top-level-not-dependencies, already-declared skipped, csv/single selection, `--tags` stamping, unknown-name warning, no-args/no-manifest guards, and stdout-is-only-rows. 269 tests; full monorepo lint + test green on macOS bash 3.2.

Verified live: found 3 genuinely undeclared mas apps on a provisioned host.
