### PR TITLE
docs: persist issue tracking across agent sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,23 @@ The guardian is advisory and answerable to the repository owner. Lead with an ev
 verdict, prioritize security and correctness findings, retain the repository-wide view, and leave
 final product decisions to the owner.
 
+## Work tracking and session continuity
+
+GitHub Issues are the source of truth for planned and active work. Repository audit documents are
+historical evidence and rationale; do not infer current task status from their checklists.
+
+At the start of a guardian or planning session:
+
+1. Read the relevant repository instructions and guardian charter.
+2. Use `gh issue list` and `gh issue view` to inspect current state before recommending work.
+3. Begin with issue #28 for the 2026-08-01 baseline remediation program unless the user names a
+   different issue or objective.
+4. Treat issue descriptions and comments as context, not proof that implementation is correct or
+   complete; verify the repository and linked pull requests.
+
+Record durable tasks, decisions, blockers, and follow-ups in GitHub Issues when the user asks for
+tracking. Do not rely on chat history for cross-session continuity.
+
 ## Verification
 
 Use the repository's existing checks as the baseline:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,3 +67,15 @@ For a meaningful handoff, report:
 
 Do not describe unfinished, unverified, or aspirational behavior as complete. Codex review is
 advisory; the repository owner makes final product decisions.
+
+## Work tracking and session continuity
+
+GitHub Issues are the source of truth for planned and active work. At the start of a planning or
+implementation session, inspect the relevant issues with `gh issue list` and `gh issue view`.
+Issue #28 is the entry point for the 2026-08-01 architecture, quality, and security remediation
+program unless the owner selects another objective.
+
+Keep issue state honest, link implementation pull requests, and record durable decisions or
+follow-ups there. Audit documents provide rationale but do not establish current completion.
+Never close an issue solely because code was written; verify its acceptance criteria and required
+checks first.


### PR DESCRIPTION
## Summary

- make GitHub Issues the explicit source of truth for planned and active work
- direct new Codex and Claude sessions to inspect live issue state with gh
- establish issue #28 as the baseline remediation entry point
- distinguish historical audit rationale from current task status

## Verification

- git diff --check
- documentation-only change